### PR TITLE
Update CkHelper.php

### DIFF
--- a/src/View/Helper/CkHelper.php
+++ b/src/View/Helper/CkHelper.php
@@ -32,7 +32,7 @@ class CkHelper extends Helper
 
         $defaultOptions = ['type' => 'textarea', 'label' => false, 'error' => false, 'required' => false];
 
-        $options = array_merge($options, $defaultOptions);
+        $options = array_merge($defaultOptions, $options);
 
         $lines[] = $this->Form->error($input);
         $lines[] = $this->Form->input($input, $options);


### PR DESCRIPTION
defaultOptions did overwrite custom options.

http://php.net/manual/en/function.array-merge.php
If the input arrays have the same string keys, **then the later value for that key will overwrite the previous one**. If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended.