### PR TITLE
remove dublicate label

### DIFF
--- a/src/View/Helper/CkHelper.php
+++ b/src/View/Helper/CkHelper.php
@@ -24,12 +24,6 @@ class CkHelper extends Helper
 
         $lines[] = $this->Html->script($ckEditorUrl);
 
-        if (!empty($options['label'])) {
-            $lines[] = $this->Form->label($input, $options['label']);
-        } else {
-            $lines[] = $this->Form->label($input);
-        }
-
         $defaultOptions = ['type' => 'textarea', 'label' => false, 'error' => false, 'required' => false];
 
         $options = array_merge($defaultOptions, $options);


### PR DESCRIPTION
heya again :D
why did u make a extra label generation?
the $this->form->input() outputs a label (within the correct div) if given in options.

with this lines i get double labels, so i removed them.

maybe it did not work for you cuz of the now fixed options array_merge bug.